### PR TITLE
Fix for attempt to call Zend_Mail->getMail()

### DIFF
--- a/app/code/community/Fooman/EmailAttachments/Helper/Data.php
+++ b/app/code/community/Fooman/EmailAttachments/Helper/Data.php
@@ -58,12 +58,12 @@ class Fooman_EmailAttachments_Helper_Data extends Mage_Core_Helper_Abstract
     {
         try {
             $this->debug('ADDING ATTACHMENT: ' . $file);
-            $mailObj->getMail()->setType(Zend_Mime::MULTIPART_MIXED);
+            if (!($mailObj instanceof Zend_Mail)) {
+                $mailObj = $mailObj->getMail();
+            }
+            $mailObj->setType(Zend_Mime::MULTIPART_MIXED);
             $filePath = Mage::getBaseDir('media') . DS . 'pdfs' . DS .$file;
             if (file_exists($filePath)) {
-                if (!($mailObj instanceof Zend_Mail)) {
-                    $mailObj = $mailObj->getMail();
-                }
                 $mailObj->createAttachment(
                     file_get_contents($filePath),
                     'application/pdf',


### PR DESCRIPTION
Here is fix for sending email from queue in Magento CE 1.9.1 / EE 1.14.1
Cron task was failing on attempt to call getMail() method on Zend_Mail object