### PR TITLE
Fix for button override

### DIFF
--- a/app/code/community/Fooman/EmailAttachments/Helper/Data.php
+++ b/app/code/community/Fooman/EmailAttachments/Helper/Data.php
@@ -172,7 +172,7 @@ class Fooman_EmailAttachments_Helper_Data extends Mage_Core_Helper_Abstract
                 'label'   => Mage::helper('sales')->__('Print'),
                 'class'   => 'save',
                 'onclick' => 'setLocation(\'' . $this->getPrintUrl($block) . '\')'
-            ), 0, 30
+            ), 0, 25
         );
     }
 


### PR DESCRIPTION
Hi,
I have encountered strangest behavior - our client reported missing "Credit Memo" button on order view page. Turns out that button was overridden by "Print" button. In ```getButtonsHtml($area)``` button are reassign to internal array that is using ```sort_order``` as array key. By default buttons without explicit ```sort_order``` are assigned with sequential button number multiplied by ten. This means that print button with sort_order equal to 30 is likely to override fourth button added without explicit ```sort_order```.