### PR TITLE
Email Queue: sending attachments for new order when updating order

### DIFF
--- a/app/code/community/Fooman/EmailAttachments/Model/Core/Email/Queue.php
+++ b/app/code/community/Fooman/EmailAttachments/Model/Core/Email/Queue.php
@@ -68,7 +68,6 @@ class Fooman_EmailAttachments_Model_Core_Email_Queue extends Mage_Core_Model_Ema
                     Mage::dispatchEvent(
                         'fooman_emailattachments_before_send_queue',
                         array(
-                            'update'         => $message->getEventType() == 'update_order',
                             'mailer'         => $mailer,
                             'message'        => $message,
                             'mail_transport' => $mailTransport

--- a/app/code/community/Fooman/EmailAttachments/Model/Core/Email/Queue.php
+++ b/app/code/community/Fooman/EmailAttachments/Model/Core/Email/Queue.php
@@ -68,10 +68,10 @@ class Fooman_EmailAttachments_Model_Core_Email_Queue extends Mage_Core_Model_Ema
                     Mage::dispatchEvent(
                         'fooman_emailattachments_before_send_queue',
                         array(
+                            'update'         => $message->getEventType() == 'update_order',
                             'mailer'         => $mailer,
                             'message'        => $message,
                             'mail_transport' => $mailTransport
-
                         )
                     );
                     //END EDIT

--- a/app/code/community/Fooman/EmailAttachments/Model/Observer.php
+++ b/app/code/community/Fooman/EmailAttachments/Model/Observer.php
@@ -285,7 +285,7 @@ class Fooman_EmailAttachments_Model_Observer
         if ($message->getEntityType() == 'order') {
             $order = Mage::getModel('sales/order')->load($message->getEntityId());
             $storeId = $order->getStoreId();
-            $update = false;
+            $update = $message->getEventType() == 'update_order';
             $configPath = $update ? 'order_comment' : 'order';
 
             if (Mage::getStoreConfig('sales_email/' . $configPath . '/attachpdf', $storeId)) {
@@ -303,7 +303,7 @@ class Fooman_EmailAttachments_Model_Observer
             for ($i = 0; $i <= 5; $i++) {
                 $fileAttachment = Mage::getStoreConfig('sales_email/'.$configPath.'/attachfile_'.$i, $storeId);
                 if ($fileAttachment) {
-                    Mage::helper('emailattachments')->addFileAttachment($fileAttachment, $mailTemplate);
+                    Mage::helper('emailattachments')->addFileAttachment($fileAttachment, $mailer);
                 }
             }
         }


### PR DESCRIPTION
Fixes two issues:
* When using email queue emails with order updates were sending attachments for create order emails
* Issue with multiple attachments causing email not to be sent at all (attempting to add attachment to null mailer object)