### PR TITLE
Optimise Compatibility With Mandrill

### DIFF
--- a/app/code/community/Fooman/EmailAttachments/Helper/Data.php
+++ b/app/code/community/Fooman/EmailAttachments/Helper/Data.php
@@ -61,7 +61,9 @@ class Fooman_EmailAttachments_Helper_Data extends Mage_Core_Helper_Abstract
             if (!($mailObj instanceof Zend_Mail)) {
                 $mailObj = $mailObj->getMail();
             }
-            $mailObj->setType(Zend_Mime::MULTIPART_MIXED);
+            if (method_exists($mailObj, 'setType')) {
+                $mailObj->setType(Zend_Mime::MULTIPART_MIXED);
+            }
             $filePath = Mage::getBaseDir('media') . DS . 'pdfs' . DS .$file;
             if (file_exists($filePath)) {
                 $mailObj->createAttachment(
@@ -106,7 +108,7 @@ class Fooman_EmailAttachments_Helper_Data extends Mage_Core_Helper_Abstract
                 } else {
                     $processor = $cmsHelper->getPageTemplateProcessor();
                     $content = $processor->filter($agreement->getContent());
-                    if (!($mailObj instanceof Zend_Mail)) {
+                    if (!($mailObj instanceof Zend_Mail) && !($mailObj instanceof Mandrill_Message)) {
                         $mailObj = $mailObj->getMail();
                     }
                     if ($agreement->getIsHtml()) {
@@ -115,13 +117,11 @@ class Fooman_EmailAttachments_Helper_Data extends Mage_Core_Helper_Abstract
                         <title>' . $agreement->getName() . '</title></head><body>'
                             . $content . '</body></html>';
 
-                        $mp = new Zend_Mime_Part($html);
-                        $mp->encoding = Zend_Mime::ENCODING_BASE64;
-                        $mp->type = 'text/html; charset=UTF-8';
-                        $mp->charset = 'UTF-8';
-                        $mp->disposition = Zend_Mime::DISPOSITION_ATTACHMENT;
-                        $mp->filename = $this->_encodedFileName($agreement->getName() . '.html');
-                        $mailObj->addAttachment($mp);
+                        $mailObj->createAttachment(
+                            $html, 'text/html',
+                            Zend_Mime::DISPOSITION_ATTACHMENT, Zend_Mime::ENCODING_BASE64,
+                            $this->_encodedFileName($agreement->getName() . '.html')
+                        );
                     } else {
                         $mailObj->createAttachment(
                             Mage::helper('core')->escapeHtml($content), 'text/plain',


### PR DESCRIPTION
- The `setType` method is not available on objects of type `Mandrill_Message`.
- The `addAttachment` method is not available on objects of type `Mandrill_Message`, but the `createAttachment` method is. I do not see any disadvantage by using `createAttachment`.