### PR TITLE
Solve #25 Add mails to email queue, instead of to send them directly.

### DIFF
--- a/app/code/community/Fooman/EmailAttachments/Model/Core/Email/Template/Mailer.php
+++ b/app/code/community/Fooman/EmailAttachments/Model/Core/Email/Template/Mailer.php
@@ -32,6 +32,7 @@ class Fooman_EmailAttachments_Model_Core_Email_Template_Mailer extends Mage_Core
             $emailTemplate->setQueue($this->getQueue());
             // Set required design parameters and delegate email sending to Mage_Core_Model_Email_Template
             $emailTemplate->setDesignConfig(array('area' => 'frontend', 'store' => $this->getStoreId()))
+                ->setQueue($this->getQueue())
                 ->sendTransactional(
                     $this->getTemplateId(),
                     $this->getSender(),


### PR DESCRIPTION
If magento mail template is not aware of a queue, magento is send emails directly instead of to add them to queue.